### PR TITLE
build erlang only if the source was changed

### DIFF
--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -11,16 +11,21 @@
   get_url:
     url: "http://erlang.org/download/otp_src_{{erlang_version}}.tar.gz"
     dest: "/tmp/otp_src_{{erlang_version}}.tar.gz"
+  register: erlang_downloaded
 
 - name: Erlang | Unpack the compressed erlang source
   command: tar -xvzf /tmp/otp_src_{{erlang_version}}.tar.gz chdir=/tmp creates=/tmp/otp_src_{{erlang_version}}/README.md
+  when: erlang_downloaded.changed
 
 - name: Erlang | Build erlang from source - pt. 1 (configure)
   command: "./configure chdir=/tmp/otp_src_{{erlang_version}}"
+  when: erlang_downloaded.changed
 
 - name: Erlang | Build erlang from source - pt. 2 (make)
   command: "make chdir=/tmp/otp_src_{{erlang_version}}"
+  when: erlang_downloaded.changed
 
 - name: Erlang | Build erlang from source - pt. 1 (make install)
   sudo: true
   command: "make install chdir=/tmp/otp_src_{{erlang_version}}"
+  when: erlang_downloaded.changed


### PR DESCRIPTION
There is no need to build erlang every time we download the source.
